### PR TITLE
ci: fix source_repo_path in template_base_sync workflow

### DIFF
--- a/.github/workflows/template_base_sync.yml
+++ b/.github/workflows/template_base_sync.yml
@@ -16,6 +16,6 @@ jobs:
         uses: AndreasAugustin/actions-template-sync@v0.3.0-draft
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          source_repo_path: https://github.com/fabriziocacicia/template_base.git
+          source_repo_path: fabriziocacicia/template_base
           upstream_branch: main 
           pr_labels: template-update # defaults to chore,template-sync


### PR DESCRIPTION
The source_repo_path accepts only `owner/repo` format, not the entire repo url